### PR TITLE
Support getting branch_tag on pull_request event

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: Main
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   print_branch_tag:

--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,13 @@
 name: Branch Tag Action
 description: Get branch tag and set to ENV
 branding:
-  icon: 'git-branch'  
+  icon: 'git-branch'
   color: 'purple'
 inputs:
   ref:
     description: 'The branch or tag ref'
     required: true
-    default: ${{ github.ref }}
+    default: ${{ github.head_ref || github.ref }}
 runs:
   using: docker
   image: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,9 +4,11 @@ REF="${1#refs/}"
 BRANCH_NAME="${REF#heads/}"
 TAG_NAME="${REF#tags/}"
 
-if [[ $BRANCH_NAME == master ]]; then
+if [[ $BRANCH_NAME == master || $BRANCH_NAME == main ]]
+then
     BRANCH_TAG=latest
-    elif [[ $TAG_NAME != $REF ]]; then
+elif [[ $TAG_NAME != $REF ]]
+then
     BRANCH_TAG=$TAG_NAME
 else
     BRANCH_TAG="${BRANCH_NAME//\//-}"


### PR DESCRIPTION
## What happened

Support getting branch_tag on pull_request event

## Insight

Just check the `GITHUB_HEAD_REF` first, if there is no value, then get `GITHUB_REF`

## Proof Of Work

Check this action result:
https://github.com/nimblehq/branch-tag-action/runs/1389519860?check_suite_focus=true