### PR TITLE
Support 'main' branch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,9 +4,11 @@ REF="${1#refs/}"
 BRANCH_NAME="${REF#heads/}"
 TAG_NAME="${REF#tags/}"
 
-if [[ $BRANCH_NAME == master ]]; then
+if [[ $BRANCH_NAME == master || $BRANCH_NAME == main ]]
+then
     BRANCH_TAG=latest
-    elif [[ $TAG_NAME != $REF ]]; then
+elif [[ $TAG_NAME != $REF ]]
+then
     BRANCH_TAG=$TAG_NAME
 else
     BRANCH_TAG="${BRANCH_NAME//\//-}"


### PR DESCRIPTION
## What happened

Github renamed the default branch from `master` to `main`, so we need to support that new branch name
## Insight

https://github.com/github/renaming

## Proof Of Work

Use `./entrypoint.sh main` to test