### PR TITLE
[#5] Fix: Deprecation warnings with set-output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,4 +15,4 @@ else
 fi
 
 echo "BRANCH_TAG=$BRANCH_TAG" >> $GITHUB_ENV
-echo "name=branch_tag::$BRANCH_TAG" >> $GITHUB_OUTPUT
+echo "branch_tag=$BRANCH_TAG" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,4 +15,4 @@ else
 fi
 
 echo "BRANCH_TAG=$BRANCH_TAG" >> $GITHUB_ENV
-echo "::set-output name=branch_tag::$BRANCH_TAG"
+echo "name=branch_tag::$BRANCH_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Closes #5 

## What happened

Update the entrypoint hell shell script with the new syntax to declare the output.

## Insights

See official documentation: [github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

## Proof Of Work

Requires to be tested manually on Compass